### PR TITLE
fix: simplify Umami loading condition for production

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,10 +22,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Determine if we should load analytics
-  const shouldLoadAnalytics = process.env.NODE_ENV === 'production' && 
-    (process.env.VERCEL_URL?.includes('ai-generative-engine-optimization.com') || 
-     process.env.NEXT_PUBLIC_DOMAIN === 'ai-generative-engine-optimization.com');
+  // Load analytics script in production (all domains)
+  // Domain filtering is handled in analytics utility
+  const shouldLoadAnalytics = process.env.NODE_ENV === 'production';
 
   return (
     <html lang="en">


### PR DESCRIPTION
- Remove complex domain checking in layout.tsx
- Load script on ALL production domains (ai-generative-engine-optimization.com + previews)
- Domain filtering remains in analytics utility for event tracking
- Ensures script loads properly in production environment

This fixes the issue where Umami script wasn't loading due to overly restrictive conditions.