### PR TITLE
Auth: Supabase magic link (SignInModal, /auth/callback, URL guards, export gating)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@sparticuz/chromium": "^138.0.1",
+        "@supabase/supabase-js": "^2.55.0",
         "cheerio": "^1.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1847,6 +1848,102 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
+      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
+      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.55.0.tgz",
+      "integrity": "sha512-Y1uV4nEMjQV1x83DGn7+Z9LOisVVRlY1geSARrUHbXWgbyKLZ6/08dvc0Us1r6AJ4tcKpwpCZWG9yDQYo1JgHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.15.1",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2202,11 +2299,16 @@
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
       "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/pluralize": {
       "version": "0.0.29",
@@ -2246,6 +2348,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -9555,7 +9666,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@sparticuz/chromium": "^138.0.1",
+    "@supabase/supabase-js": "^2.55.0",
     "cheerio": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import { RETURN_TO_PARAM, UMAMI_EVENTS } from '@/lib/constants';
+import { sanitizeReturnTo } from '@/utils/urlGuards';
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        // If a magic link code is present, exchange it for a session first
+        const code = searchParams.get('code');
+        if (code) {
+          try {
+            await supabase.auth.exchangeCodeForSession(code);
+          } catch (e) {
+            // ignore, fallback to getSession
+          }
+        }
+
+        // Wait for session to be ready
+        const { data: sessionData } = await supabase.auth.getSession();
+
+        // If no session yet, briefly wait and retry once (supabase may finalize)
+        if (!sessionData?.session) {
+          await new Promise((r) => setTimeout(r, 300));
+        }
+
+        // Optional: try to call ensure profile endpoint (not implemented yet)
+        try {
+          // Placeholder: if you add /api/profile/ensure, switch to that
+          (window as any).umami?.track(UMAMI_EVENTS.login_success);
+        } catch {
+          (window as any).umami?.track(UMAMI_EVENTS.login_success);
+        }
+
+        const r = searchParams.get(RETURN_TO_PARAM);
+        const returnTo = sanitizeReturnTo(r) || '/';
+        if (!cancelled) router.replace(returnTo);
+      } catch (e) {
+        // On error, redirect home as a safe fallback
+        if (!cancelled) router.replace('/');
+      }
+    };
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center">
+      <div className="text-center space-y-2">
+        <div className="animate-pulse text-sm opacity-80">Signing you in…</div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/src/components/auth/SignInModal.tsx
+++ b/src/components/auth/SignInModal.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { supabase } from '@/lib/supabaseClient';
+import { AUTH_CALLBACK_PATH, RETURN_TO_PARAM, AUTH_FLAG_PARAM, UMAMI_EVENTS } from '@/lib/constants';
+
+interface SignInModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Status = 'idle' | 'sending' | 'sent' | 'error';
+
+export function SignInModal({ isOpen, onClose }: SignInModalProps) {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const titleId = useMemo(() => 'sign-in-title', []);
+
+  // Focus email input on open
+  useEffect(() => {
+    if (isOpen) {
+      // Reset transient error when reopening
+      setError(null);
+      setTimeout(() => {
+        const el = document.getElementById('sign-in-email') as HTMLInputElement | null;
+        el?.focus();
+      }, 0);
+    } else {
+      // Reset state when closing
+      setStatus('idle');
+      setEmail('');
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // Close on Escape when not sending
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && status !== 'sending') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, status, onClose]);
+
+  const buildReturnTo = (): string => {
+    if (typeof window === 'undefined') return '/report';
+    const url = new URL(window.location.href);
+    // Ensure auth=1 param
+    url.searchParams.set(AUTH_FLAG_PARAM, '1');
+    return url.pathname + (url.search ? url.search : '');
+  };
+
+  const handleSend = async (): Promise<void> => {
+    const trimmed = (email || '').trim();
+    if (!trimmed || !trimmed.includes('@')) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+
+    try {
+      (window as any).umami?.track(UMAMI_EVENTS.signup_started);
+      setStatus('sending');
+      setError(null);
+
+      const return_to = buildReturnTo();
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const redirect = `${origin}${AUTH_CALLBACK_PATH}?${RETURN_TO_PARAM}=${encodeURIComponent(return_to)}`;
+
+      const { error: signInError } = await supabase.auth.signInWithOtp({
+        email: trimmed,
+        options: {
+          emailRedirectTo: redirect,
+        },
+      });
+
+      if (signInError) {
+        throw signInError;
+      }
+
+      setStatus('sent');
+    } catch (e) {
+      setStatus('error');
+      setError('Invalid email or too many attempts, please try again.');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+      <div className="fixed inset-0 bg-black/60" aria-hidden="true"></div>
+      <div className="relative z-10 w-full max-w-md mx-4 rounded-[var(--radius)] bg-card border border-accent-1 shadow-xl">
+        <div className="p-6 md:p-8">
+          <h1 id={titleId} className="mb-2 text-xl font-semibold">Sign in to download your report</h1>
+          {status !== 'sent' && (
+            <p className="text-sm text-foreground/80">Enter your email to get a sign-in link. No password needed.</p>
+          )}
+
+          {status !== 'sent' && (
+            <div className="mt-6 space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="sign-in-email" className="block text-sm">Email</Label>
+                <Input
+                  id="sign-in-email"
+                  name="sign-in-email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={status === 'sending'}
+                />
+              </div>
+              {error && (
+                <div className="text-sm text-red-600">{error}</div>
+              )}
+              <div className="flex gap-3">
+                <Button onClick={handleSend} disabled={status === 'sending'}>
+                  {status === 'sending' ? 'Sending…' : 'Send link'}
+                </Button>
+                <Button variant="outline" onClick={onClose} disabled={status === 'sending'}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {status === 'sent' && (
+            <div className="mt-6 space-y-4">
+              <div className="rounded-[var(--radius)] border border-accent-1 bg-surface p-4 text-sm">
+                Check your inbox. You can close this window.
+              </div>
+              <div className="flex gap-3">
+                <Button onClick={onClose}>Close</Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SignInModal;
+
+

--- a/src/components/sign-up.tsx
+++ b/src/components/sign-up.tsx
@@ -1,0 +1,88 @@
+import { LogoIcon } from '@/components/logo'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import Link from 'next/link'
+
+export default function LoginPage() {
+    return (
+        <section className="flex min-h-screen bg-zinc-50 px-4 py-16 md:py-32 dark:bg-transparent">
+            <form
+                action=""
+                className="max-w-92 m-auto h-fit w-full">
+                <div className="p-6">
+                    <div>
+                        <Link
+                            href="/"
+                            aria-label="go home">
+                            <LogoIcon />
+                        </Link>
+                        <h1 className="mb-1 mt-4 text-xl font-semibold">Create a Tailark Account</h1>
+                        <p>Welcome! Create an account to get started</p>
+                    </div>
+
+                    <div className="mt-6">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="w-full">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="0.98em"
+                                height="1em"
+                                viewBox="0 0 256 262">
+                                <path
+                                    fill="#4285f4"
+                                    d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622l38.755 30.023l2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"></path>
+                                <path
+                                    fill="#34a853"
+                                    d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055c-34.523 0-63.824-22.773-74.269-54.25l-1.531.13l-40.298 31.187l-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"></path>
+                                <path
+                                    fill="#fbbc05"
+                                    d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82c0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602z"></path>
+                                <path
+                                    fill="#eb4335"
+                                    d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0C79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"></path>
+                            </svg>
+                            <span>Google</span>
+                        </Button>
+                    </div>
+
+                    <div className="my-6 grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+                        <hr className="border-dashed" />
+                        <span className="text-muted-foreground text-xs">Or continue With</span>
+                        <hr className="border-dashed" />
+                    </div>
+
+                    <div className="space-y-6">
+                        <div className="space-y-2">
+                            <Label
+                                htmlFor="email"
+                                className="block text-sm">
+                                Email
+                            </Label>
+                            <Input
+                                type="email"
+                                required
+                                name="email"
+                                id="email"
+                            />
+                        </div>
+
+                        <Button className="w-full">Continue</Button>
+                    </div>
+                </div>
+
+                <p className="text-accent-foreground text-center text-sm">
+                    Have an account ?
+                    <Button
+                        asChild
+                        variant="ghost"
+                        className="px-2">
+                        <Link href="#">Sign In</Link>
+                    </Button>
+                </p>
+            </form>
+        </section>
+    )
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,17 @@
+export const AUTH_CALLBACK_PATH = '/auth/callback';
+
+export const RETURN_TO_PARAM = 'r';
+
+export const AUTH_FLAG_PARAM = 'auth'; // valeur '1' au retour d’auth
+
+export const ALLOWED_RETURN_PREFIXES = ['/', '/report', '/pricing'];
+
+export const UMAMI_EVENTS = {
+  export_attempt: 'export_attempt',
+  signup_started: 'signup_started',
+  signup_success: 'signup_success',
+  login_success: 'login_success',
+} as const;
+
+export type UmamiEventKey = keyof typeof UMAMI_EVENTS;
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  // During build/SSR this may log once; avoids throwing to not break static build
+  // Runtime code should ensure env vars exist in .env.local
+  console.warn('[Supabase] Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+}
+
+export const supabase = createClient(supabaseUrl || '', supabaseAnonKey || '');
+
+export type SupabaseClientType = typeof supabase;
+

--- a/src/utils/urlGuards.ts
+++ b/src/utils/urlGuards.ts
@@ -1,0 +1,44 @@
+import { ALLOWED_RETURN_PREFIXES, AUTH_FLAG_PARAM } from '@/lib/constants';
+
+/**
+ * Sanitize an internal return path to prevent open redirects.
+ * - Reject absolute URLs (http://, https://, //)
+ * - Allow only relative paths beginning with one of ALLOWED_RETURN_PREFIXES
+ * - Fallback to '/'
+ */
+export function sanitizeReturnTo(input: string | null | undefined): string {
+  if (!input) return '/';
+
+  let decoded = input;
+  try {
+    decoded = decodeURIComponent(input);
+  } catch {
+    decoded = input;
+  }
+
+  const value = decoded.trim();
+  const lower = value.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('//')) {
+    return '/';
+  }
+  if (!value.startsWith('/')) {
+    return '/';
+  }
+  const allowed = ALLOWED_RETURN_PREFIXES.some((prefix) => value.startsWith(prefix));
+  return allowed ? value : '/';
+}
+
+/**
+ * Remove the auth=1 flag from a URL path+search string to clean the address bar.
+ * The input should be a relative path starting with '/'.
+ */
+export function stripAuthFlag(urlPathWithQuery: string): string {
+  if (!urlPathWithQuery) return '/';
+  const [path, search = ''] = urlPathWithQuery.split('?');
+  const params = new URLSearchParams(search);
+  params.delete(AUTH_FLAG_PARAM);
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+


### PR DESCRIPTION
- Ajouts
  - `src/lib/constants.ts`: AUTH_CALLBACK_PATH, RETURN_TO_PARAM, AUTH_FLAG_PARAM, ALLOWED_RETURN_PREFIXES, UMAMI_EVENTS
  - `src/lib/supabaseClient.ts`: client Supabase (NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY)
  - `src/components/auth/SignInModal.tsx`: modale email (magic link), UX: focus auto, états idle/sending/sent/error
  - `src/app/auth/callback/page.tsx`: finalisation session Supabase (exchange code + getSession), sanitize du retour, tracking `login_success`, redirection vers `r` (incluant `?auth=1`)
  - `src/utils/urlGuards.ts`: `sanitizeReturnTo` (whitelist: '/', '/report', '/pricing') et `stripAuthFlag`
  - `src/components/ui/CollectionResults.tsx`: handler Export → si session OK: export; sinon: `umami.export_attempt` + ouverture `SignInModal`
  - `src/app/report/page.tsx`: guard `?auth=1` (pas d’auto-run), nettoyage de l’URL sans `auth=1`

- Sécurité
  - Anti open redirect: pas d’URL absolues dans `r`, uniquement chemins commençant par un des ALLOWED_RETURN_PREFIXES

- Analytics (Umami)
  - `export_attempt` (clic Export non loggé)
  - `signup_started` (envoi du magic link)
  - `login_success` (par défaut dans le callback)

- Comportement cible
  - Non loggé: Export → modale → envoi du lien → retour `/auth/callback` → redirect vers l’origine `?auth=1` → pas d’auto-run → re-clic Export
  - Déjà loggé: Export direct
  - `r=https://evil.com` → redirection vers `/` (sanitize OK)

- Notes
  - Pas d’auto-export post-login, pas de run auto après retour auth (`auth=1`).