### PR TITLE
update: Umami events (signup/login/export) + mises à jour de contenu

### DIFF
--- a/src/app/auth/callback/CallbackRunner.tsx
+++ b/src/app/auth/callback/CallbackRunner.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import { RETURN_TO_PARAM, UMAMI_EVENTS } from '@/lib/constants';
+import { sanitizeReturnTo } from '@/utils/urlGuards';
+
+export default function CallbackRunner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const code = searchParams.get('code');
+        if (code) {
+          try { await supabase.auth.exchangeCodeForSession(code); } catch {}
+        }
+        const { data: sessionData } = await supabase.auth.getSession();
+        if (!sessionData?.session) { await new Promise(r => setTimeout(r, 300)); }
+
+        try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+
+        const r = searchParams.get(RETURN_TO_PARAM);
+        const returnTo = sanitizeReturnTo(r) || '/';
+        if (!cancelled) router.replace(returnTo);
+      } catch {
+        if (!cancelled) router.replace('/');
+      }
+    };
+    run();
+
+    return () => { cancelled = true; };
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center">
+      <div className="text-center space-y-2">
+        <div className="animate-pulse text-sm opacity-80">Signing you in…</div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/src/app/auth/callback/CallbackRunner.tsx
+++ b/src/app/auth/callback/CallbackRunner.tsx
@@ -22,7 +22,44 @@ export default function CallbackRunner() {
         const { data: sessionData } = await supabase.auth.getSession();
         if (!sessionData?.session) { await new Promise(r => setTimeout(r, 300)); }
 
-        try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+        // Determine signup vs login based on presence of profile
+        try {
+          const { data: userData } = await supabase.auth.getUser();
+          const user = userData?.user;
+          if (user) {
+            // Check if profile exists
+            const { data: existingList, error: selectError } = await supabase
+              .from('profiles')
+              .select('id')
+              .eq('id', user.id)
+              .limit(1);
+
+            const exists = Array.isArray(existingList) && existingList.length > 0;
+
+            if (exists) {
+              try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+            } else {
+              const { error: insertError } = await supabase
+                .from('profiles')
+                .insert([{ id: user.id, email: user.email }]);
+
+              if (!insertError) {
+                try { (window as any).umami?.track(UMAMI_EVENTS.signup_success); } catch {}
+              } else {
+                const code = (insertError as any)?.code || '';
+                const message = ((insertError as any)?.message || '').toString();
+                const isDuplicate = code === '23505' || /duplicate/i.test(message);
+                try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+              }
+            }
+          } else {
+            // No user info; fallback to login_success when session exists
+            try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+          }
+        } catch {
+          // If any error while checking/inserting profile, still consider login success
+          try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
+        }
 
         const r = searchParams.get(RETURN_TO_PARAM);
         const returnTo = sanitizeReturnTo(r) || '/';

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react';
 import CallbackRunner from './CallbackRunner';
 
 export const dynamic = 'force-dynamic';
-export const revalidate = 0 as const;
+export const revalidate = 0;
 
 export default function AuthCallbackPage() {
   return (

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,52 +1,8 @@
-"use client";
-
-import { Suspense, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
-import { RETURN_TO_PARAM, UMAMI_EVENTS } from '@/lib/constants';
-import { sanitizeReturnTo } from '@/utils/urlGuards';
+import { Suspense } from 'react';
+import CallbackRunner from './CallbackRunner';
 
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
-
-function CallbackRunner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const run = async () => {
-      try {
-        const code = searchParams.get('code');
-        if (code) {
-          try { await supabase.auth.exchangeCodeForSession(code); } catch {}
-        }
-        const { data: sessionData } = await supabase.auth.getSession();
-        if (!sessionData?.session) { await new Promise(r => setTimeout(r, 300)); }
-
-        try { (window as any).umami?.track(UMAMI_EVENTS.login_success); } catch {}
-
-        const r = searchParams.get(RETURN_TO_PARAM);
-        const returnTo = sanitizeReturnTo(r) || '/';
-        if (!cancelled) router.replace(returnTo);
-      } catch {
-        if (!cancelled) router.replace('/');
-      }
-    };
-    run();
-
-    return () => { cancelled = true; };
-  }, [router, searchParams]);
-
-  return (
-    <div className="min-h-[50vh] flex items-center justify-center">
-      <div className="text-center space-y-2">
-        <div className="animate-pulse text-sm opacity-80">Signing you in…</div>
-      </div>
-    </div>
-  );
-}
+export const revalidate = 0 as const;
 
 export default function AuthCallbackPage() {
   return (

--- a/src/components/content-4.tsx
+++ b/src/components/content-4.tsx
@@ -8,7 +8,7 @@ export default function ContentSection() {
                     <h2 className="text-4xl font-semibold lg:text-5xl">Search behavior has already changed</h2>
                     <div className="space-y-6">
                         <p>
-                            Ask yourself: when you need quick answers, do you go to Google first — or do you ask ChatGPT?
+                            Ask yourself: when you need quick answers, do you go to Google first or do you ask ChatGPT, Perplexity or Gemini?
                         </p>
                         <div className="space-y-4">
                             <p>Your customers, or your clients’ customers, now:</p>

--- a/src/components/features-1.tsx
+++ b/src/components/features-1.tsx
@@ -9,12 +9,13 @@ export default function Features() {
                 <div className="text-left md:text-center">
                     <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Turn your website into an AI-cited source</h2>
                     <p className="mt-4 max-w-3xl mx-auto">
-                        Forget theory, here’s how you make AI engines see you.
+                        Forget theory, here's how you make AI engines see you.
+                        <br />
                         <br />
                         Run a full AI visibility audit of your site, checking how well LLMs like ChatGPT, Claude, and Gemini can find, understand, and quote your content.
                         <br />
                         <br />
-                        You’ll see exactly what’s blocking you and get clear, prioritized actions to fix it.
+                        You'll see exactly what's blocking you and get clear, prioritized actions to fix it.
                     </p>
                 </div>
                 <div className="@min-4xl:max-w-full @min-4xl:grid-cols-3 mx-auto mt-8 grid max-w-sm gap-6 md:mt-16 md:grid-cols-3">

--- a/src/components/features-5.tsx
+++ b/src/components/features-5.tsx
@@ -8,14 +8,12 @@ export default function FeaturesSection() {
                 <div className="grid items-center gap-12 md:grid-cols-2 md:gap-12 lg:grid-cols-2 lg:gap-24">
                     <div>
                         <div className="md:pr-6 lg:pr-0">
-                            <h2 className="text-4xl font-semibold lg:text-5xl">Why ranking on Google isn’t enough anymore</h2>
+                            <h2 className="text-4xl font-semibold lg:text-5xl">Ranking on Google isn't enough anymore</h2>
                             <p className="mt-6">
-                                Ranking on Google is no longer enough.
+                                Conversational AIs now deliver full, instant answers, cutting clicks to websites and bypassing even high-ranking pages.
                                 <br />
                                 <br />
                                 Without AI optimization, you face:
-                                <br />
-                                Conversational AIs now deliver full, instant answers — cutting clicks to websites and bypassing even high-ranking pages.
                             </p>
                         </div>
                         <ul className="mt-8 divide-y border-y *:flex *:items-center *:gap-3 *:py-3">

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,35 +1,14 @@
 import React, { useState } from 'react'
-import { SendHorizontal } from 'lucide-react'
 import { LiaLinkSolid, LiaCheckCircleSolid } from 'react-icons/lia'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { TextEffect } from '@/components/ui/text-effect'
-import { AnimatedGroup } from '@/components/ui/animated-group'
 import { HeroHeader } from './header'
 import { LogoCloud } from './logo-cloud'
 import { useRouter } from 'next/navigation'
 import { trackAnalysisStart } from '@/utils/analytics'
 import { normalizeAndValidate } from '@/utils/url'
 
-const transitionVariants = {
-    item: {
-        hidden: {
-            opacity: 0,
-            filter: 'blur(12px)',
-            y: 12,
-        },
-        visible: {
-            opacity: 1,
-            filter: 'blur(0px)',
-            y: 0,
-            transition: {
-                type: 'spring' as const,
-                bounce: 0.3,
-                duration: 1.5,
-            },
-        },
-    },
-}
+// animations retirées: TextEffect et AnimatedGroup
 
 export default function HeroSection() {
     const router = useRouter()
@@ -60,36 +39,14 @@ export default function HeroSection() {
                                 <LiaCheckCircleSolid />
                                 <span>Spot & Fix AI Issues in 1 Click</span>
                             </Badge>
-                            <TextEffect
-                                preset="fade-in-blur"
-                                speedSegment={0.3}
-                                as="h1"
-                                className="text-balance text-4xl font-semibold md:text-5xl">
+                            <h1 className="text-balance text-4xl font-semibold md:text-5xl">
                                 Make your site the source AI engines cite first
-                            </TextEffect>
-                            <TextEffect
-                                per="line"
-                                preset="fade-in-blur"
-                                speedSegment={0.3}
-                                delay={0.5}
-                                as="p"
-                                className="mx-auto mt-6 max-w-2xl text-pretty text-lg">
+                            </h1>
+                            <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg">
                                 Run a one-click audit that makes your content visible and understandable by LLMs like ChatGPT. Get a crystal-clear report with precise actions to boost your AI visibility.
-                            </TextEffect>
+                            </p>
 
-                            <AnimatedGroup
-                                variants={{
-                                    container: {
-                                        visible: {
-                                            transition: {
-                                                staggerChildren: 0.05,
-                                                delayChildren: 0.75,
-                                            },
-                                        },
-                                    },
-                                    ...transitionVariants,
-                                }}
-                                className="mt-12">
+                            <div className="mt-12">
                                 <form onSubmit={handleSubmit} className="mx-auto max-w-2xl md:max-w-3xl">
                                     <div className="bg-background has-[input:focus]:ring-muted relative grid grid-cols-[1fr_auto] items-center rounded-[calc(var(--radius)+0.75rem)] border px-3 py-2 gap-2 shadow shadow-zinc-950/5 has-[input:focus]:ring-2">
                                         <LiaLinkSolid className="pointer-events-none absolute inset-y-0 left-5 my-auto size-6 md:size-7" />
@@ -137,7 +94,7 @@ export default function HeroSection() {
                                     </div>
                                     <div className="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] mix-blend-overlay [background-size:16px_16px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)] dark:opacity-5"></div>
                                 </div>
-                            </AnimatedGroup>
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/components/ui/CollectionResults.tsx
+++ b/src/components/ui/CollectionResults.tsx
@@ -325,8 +325,10 @@ export function CollectionResults({ data, analysisResults, isLoading, isAnalysis
       a.click();
       a.remove();
       window.URL.revokeObjectURL(urlObject);
+      try { (window as any).umami?.track(UMAMI_EVENTS.export_success, { url: data.url }); } catch {}
     } catch (err) {
       console.error(err);
+      try { (window as any).umami?.track(UMAMI_EVENTS.export_failed, { url: data?.url, error: err instanceof Error ? err.message : String(err) }); } catch {}
     } finally {
       setIsExporting(false);
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const ALLOWED_RETURN_PREFIXES = ['/', '/report', '/pricing'];
 
 export const UMAMI_EVENTS = {
   export_attempt: 'export_attempt',
+  export_success: 'export_success',
+  export_failed: 'export_failed',
   signup_started: 'signup_started',
   signup_success: 'signup_success',
   login_success: 'login_success',


### PR DESCRIPTION
### Description
Cette PR ajoute le suivi d’évènements Umami sur les parcours signup/login et export, et intègre quelques ajustements de contenu sur les sections UI concernées. Objectif: mieux comprendre l’engagement (inscriptions) et l’usage de l’export, tout en gardant le flow “signup via export” inchangé.

### Changements principaux
- **Analytics (Umami)**
  - **signup_started**: déclenché au clic “Send link” dans la modale (avant l’appel Supabase).
  - **signup_success**: déclenché sur `/auth/callback` si le profil n’existait pas et vient d’être créé.
  - **login_success**: déclenché sur `/auth/callback` si le profil existait déjà (ou si l’insert renvoie un duplicate).
  - **export_attempt**: déclenché au clic “Export” quand l’utilisateur n’est pas connecté (ouverture de la modale).
  - **export_success**: déclenché lorsque le PDF est généré et le téléchargement lancé avec succès.
  - **export_failed**: déclenché si l’export échoue (erreur HTTP/exception/timeout).
- **Contenu UI**
  - Ajustements de texte sur `hero`/`features`/contenus associés.

### Détails techniques
- Ajout des clés `export_success` et `export_failed` dans `UMAMI_EVENTS`.
- Sur `/auth/callback`: détection signup vs login via la table `profiles`:
  - Select sur `profiles(id=user.id)`; si absent → tentative `insert({ id, email })`.
  - Succès insert → `signup_success`; duplicate/présent → `login_success`; fallback en cas d’erreur → `login_success`.
- Sur l’export:
  - Non connecté → ouverture modale + `export_attempt`.
  - Connecté → appel `/api/export-pdf`; en cas de succès → `export_success`, sinon → `export_failed`.

### Plan de test
- **Signup via export (non connecté)**:
  - Cliquer “Export” → la modale s’ouvre et `export_attempt` est envoyé.
  - Cliquer “Send link” → `signup_started`.
  - Suivre le lien magic → sur `/auth/callback`, si nouveau user → `signup_success`, sinon → `login_success`.
- **Export (connecté)**:
  - Cliquer “Export” → PDF téléchargé → `export_success`.
  - Simuler une erreur (par ex. couper le service export) → `export_failed`.
- Note: Umami se charge uniquement en production; en local, les évènements sont no-op/loggués pour debug.

### Impact / Risques
- Flow “signup via export” conservé tel quel.
- Hypothèse: la table `profiles` existe (PK `id` = `user.id`) et les RLS permettent `select/insert` pour l’utilisateur connecté.